### PR TITLE
Implemented Websocket functionality for route '/newRequest'

### DIFF
--- a/controllers/new-request.js
+++ b/controllers/new-request.js
@@ -4,12 +4,11 @@ const { Sockets } = require('../utils/websocket');
 // We need to send this through the web socket
 newRequestRouter.post('/newRequest', async (req, res, next) => {
   const randomString = req.body.randomString
-  console.log('randomString: ', randomString);
 
-  if (Sockets && Sockets[randomString]) {
+  if (Sockets && Sockets[randomString]) { // look for current active WebSocket connections
     Sockets[randomString].send(JSON.stringify(req.body));
     res.status(200).send({ message: 'Forwarded to front-end' });
-  } else {
+  } else { // no matching connection found
     res.status(400).send({ message: 'Client not connected with WebSocket or not found, payload not forwarded'})
   }
 });

--- a/controllers/new-request.js
+++ b/controllers/new-request.js
@@ -1,10 +1,17 @@
 const newRequestRouter = require('express').Router();
+const { Sockets } = require('../utils/websocket');
 
 // We need to send this through the web socket
 newRequestRouter.post('/newRequest', async (req, res, next) => {
-  body = req.body;
-  console.log(body);
-  res.status(200).send({ message: 'Forwarding to front-end' });
+  const randomString = req.body.randomString
+  console.log('randomString: ', randomString);
+
+  if (Sockets && Sockets[randomString]) {
+    Sockets[randomString].send(JSON.stringify(req.body));
+    res.status(200).send({ message: 'Forwarded to front-end' });
+  } else {
+    res.status(400).send({ message: 'Client not connected with WebSocket or not found, payload not forwarded'})
+  }
 });
 
 module.exports = newRequestRouter;

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -9,15 +9,15 @@ userRouter.get('/generateURL', async (req, res, next) => {
   const RANDOM_STRING_LENGTH = 10;
   const randomString = funcHelpers.generateRandomString(RANDOM_STRING_LENGTH);
 
-  const storedNewURL = await db.insertNewURL(randomString);
+  // const storedNewURL = await db.insertNewURL(randomString);
 
-  if (!storedNewURL) {
-    res.set({ 'Retry-After': 120 });
-    res
-      .status(503)
-      .json({ error: 'Could not generate new URL. Try again later.' });
-    return;
-  }
+  // if (!storedNewURL) {
+  //   res.set({ 'Retry-After': 120 });
+  //   res
+  //     .status(503)
+  //     .json({ error: 'Could not generate new URL. Try again later.' });
+  //   return;
+  // }
 
   res.status(201).json({ randomString, requests: [] });
 });

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const server = app.listen(config.PORT, () => {
   logger.info(`Server running on port ${config.PORT}...`);
 });
 
-// when App server receives request to 'upgrade' to WebSocket protocol
-// (a client sends a request to connect via WebSocket)
+// When a client sends a request to connect via WebSocket,
+// the App server receives the request to 'upgrade' to WebSocket protocol
 server.on('upgrade', (request, socket, head) => {
   // WebSocket Server handles the upgrade event
   WSServer.handleUpgrade(request, socket, head, (ws) => {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,21 @@
+const ws = require('ws');
 const http = require('http');
-
 const app = require('./app');
 const logger = require('./utils/logger');
 const config = require('./utils/config');
+const { WSServer } = require('./utils/websocket');
 // const initiateWebSocket = require('./controllers/web-socket');
+// const wsListener = new ws.WebSocketServer({ noServer: true });
 
-const server = http.createServer(app);
+// const server = http.createServer(app);
 // initiateWebSocket(server);
 
-server.listen(config.PORT, config.HOST, () => {
+const server = app.listen(config.PORT, () => {
   logger.info(`Server running on port ${config.PORT}...`);
+});
+
+server.on('upgrade', (request, socket, head) => {
+  WSServer.handleUpgrade(request, socket, head, (ws) => {
+    WSServer.emit('connection', ws, request);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -1,21 +1,18 @@
-const ws = require('ws');
-const http = require('http');
 const app = require('./app');
 const logger = require('./utils/logger');
 const config = require('./utils/config');
 const { WSServer } = require('./utils/websocket');
-// const initiateWebSocket = require('./controllers/web-socket');
-// const wsListener = new ws.WebSocketServer({ noServer: true });
-
-// const server = http.createServer(app);
-// initiateWebSocket(server);
 
 const server = app.listen(config.PORT, () => {
   logger.info(`Server running on port ${config.PORT}...`);
 });
 
+// when App server receives request to 'upgrade' to WebSocket protocol
+// (a client sends a request to connect via WebSocket)
 server.on('upgrade', (request, socket, head) => {
+  // WebSocket Server handles the upgrade event
   WSServer.handleUpgrade(request, socket, head, (ws) => {
+    //WebSocket Server opens up a socket, triggers the 'connection' event
     WSServer.emit('connection', ws, request);
   });
 });

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -1,0 +1,18 @@
+const ws = require('ws');
+const logger = require('./logger')
+
+const WSServer = new ws.WebSocketServer({ noServer: true });
+const Sockets = {};
+
+WSServer.on('connection', (socket, request) => {
+  const url = request.headers.host;
+  Sockets[url] = socket;
+  logger.info('WebSocket connected with URL: ' + url)
+
+  socket.on('close', () => {
+    delete Sockets[url];
+    logger.info('WebSocket client disconnected, delete ' + url);
+  })
+});
+
+module.exports = { WSServer, Sockets };

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -1,14 +1,17 @@
 const ws = require('ws');
 const logger = require('./logger')
 
+// initialize a WebSocket Server that works on the same port with App server
 const WSServer = new ws.WebSocketServer({ noServer: true });
 const Sockets = {};
 
+// When a client establishes a connection with WebSocket Server:
 WSServer.on('connection', (socket, request) => {
-  const url = request.headers.host;
+  const url = request.headers.host; // define unique client identifier here
   Sockets[url] = socket;
   logger.info('WebSocket connected with URL: ' + url)
 
+  // removes socket from Sockets collection when client disconnects
   socket.on('close', () => {
     delete Sockets[url];
     logger.info('WebSocket client disconnected, delete ' + url);

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -8,7 +8,7 @@ const Sockets = {};
 // When a client establishes a connection with WebSocket Server:
 WSServer.on('connection', (socket, request) => {
   const url = request.headers.host; // define unique client identifier here
-  Sockets[url] = socket;
+  Sockets[url] = socket; // store the socket with UCI
   logger.info('WebSocket connected with URL: ' + url)
 
   // removes socket from Sockets collection when client disconnects

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -7,14 +7,17 @@ const Sockets = {};
 
 // When a client establishes a connection with WebSocket Server:
 WSServer.on('connection', (socket, request) => {
-  const url = request.headers.host; // define unique client identifier here
-  Sockets[url] = socket; // store the socket with UCI
-  logger.info('WebSocket connected with URL: ' + url)
-
+  // const url = request.headers.host; // define unique client identifier here
+  // Sockets[url] = socket; // store the socket with UCI
+  logger.info('WebSocket connected')
+  socket.on('message', (msg) => {
+    const randomString = msg.toString();
+    Sockets[randomString] = socket;
+  })
   // removes socket from Sockets collection when client disconnects
   socket.on('close', () => {
-    delete Sockets[url];
-    logger.info('WebSocket client disconnected, delete ' + url);
+    // delete Sockets[url];
+    // logger.info('WebSocket client disconnected, delete ' + url);
   })
 });
 


### PR DESCRIPTION
What's happening here:
- a client visits the `display` page, wants to establish an "upgrade" to the websocket connection
- the request is sent along with the URL randomString
- WebSocket server takes over the request, creates a `socket`, store the randomString and `socket` into a hash table
- When `/newRequest` receives a POST request from 3rd-party API server, WebSocket server find the matching randomString in the hash table, and using the associated `socket` to send payload back to the client 